### PR TITLE
Allow eventType other than String

### DIFF
--- a/src/main/scala/com/thoughtworks/binding/LatestJQueryEvent.scala
+++ b/src/main/scala/com/thoughtworks/binding/LatestJQueryEvent.scala
@@ -7,7 +7,7 @@ import scala.scalajs.js
 /**
   * @author 杨博 (Yang Bo)
   */
-class LatestJQueryEvent(eventTarget: JQuery, eventType: String) extends Binding[Option[JQueryEventObject]] {
+class LatestJQueryEvent(eventTarget: JQuery, eventType: js.Any) extends Binding[Option[JQueryEventObject]] {
   private var cache: Option[JQueryEventObject] = None
   private val publisher = new SafeBuffer[ChangedListener[Option[JQueryEventObject]]]
 


### PR DESCRIPTION
ScalablyTyped generate js.Any for string literal types, e.g. typings.bootstrapLib.bootstrapLibStrings.showDOTbsDOTdropdown